### PR TITLE
feat: add subject-based context targeting and group management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple feature flags library with PostgreSQL integration, inspired by [django-
 ## Features
 
 - **Multiple targeting strategies**: Enable features for specific users, roles, groups, or percentage rollouts
+- **External subject targeting**: Assign flags (or flag groups) to external subjects like tenants or org IDs
 - **Consistent hashing**: Deterministic user bucketing for A/B testing and experimentation
 - **PostgreSQL-backed**: Reliable, transactional flag storage with your existing database
 - **CLI included**: Manage feature flags from the command line
@@ -63,6 +64,16 @@ const active = await featureFlag.isActiveForUser({
   user: "1234",
 });
 
+// Assign a flag to an external subject ID (for example, a tenant)
+await featureFlags.addSubject(flag.id, "tenant:acme");
+
+// Check if active for a broader context that includes external subject IDs
+const activeForTenant = await featureFlags.isActiveForContext({
+  name: "enable_new_checkout_20250101_gbrandt",
+  user: "1234",
+  subjects: ["tenant:acme"],
+});
+
 // Enable the feature flag for certain roles
 await featureFlags.update(flag.id, {
   roles: ["admin", "staff"],
@@ -101,9 +112,41 @@ When checking if a feature flag is active for a user, Flapjack evaluates rules i
 1. **Everyone Override** (`everyone: true/false`): If set, immediately returns this value, ignoring all other rules
 2. **User List** (`users: [...]`): If the user ID is in this list, returns `true`
 3. **Group Membership** (`groups: [...]`): If the user belongs to any specified group, returns `true`
-4. **Role Membership** (`roles: [...]`): If the user has any specified role, returns `true`
-5. **Percentage Rollout** (`percent: 0-99.9`): Uses consistent hashing to deterministically bucket users
-6. **Default**: Returns `false` if no conditions are met
+4. **External Subject Match** (`subjects: [...]`): If any provided subject matches a direct flag subject or a flag-group subject, returns `true`
+5. **Role Membership** (`roles: [...]`): If the user has any specified role, returns `true`
+6. **Percentage Rollout** (`percent: 0-99.9`): Uses consistent hashing to deterministically bucket users
+7. **Default**: Returns `false` if no conditions are met
+
+## External Subject Targeting
+
+Use subjects when identity/group membership is managed outside Flapjack (for example, tenant IDs from another system).
+
+```typescript
+const groupModel = new FeatureFlagGroupModel(pool);
+const flagModel = new FeatureFlagModel(pool);
+
+const rolloutGroup = await groupModel.create({
+  name: "checkout_rollout",
+});
+
+const checkoutFlag = await flagModel.create({
+  name: "enable_checkout_v2",
+});
+
+await groupModel.addFeatureFlag(rolloutGroup.id, checkoutFlag.id);
+
+// Attach external subject to all flags in this feature flag group
+await groupModel.addSubject(rolloutGroup.id, "tenant:acme");
+
+// You can also attach a subject directly to a single flag
+await flagModel.addSubject(checkoutFlag.id, "tenant:beta");
+
+const isActive = await flagModel.isActiveForContext({
+  name: "enable_checkout_v2",
+  user: "user_123",
+  subjects: ["tenant:acme"],
+});
+```
 
 ### Example Evaluation
 
@@ -347,6 +390,15 @@ flapjack get-by-name my_feature
 # Check if active for a user
 flapjack is-active my_feature --user user123 --roles admin
 
+# Check if multiple flags are active for a user
+flapjack are-active --names my_feature other_feature --user user123 --roles admin
+
+# Check if active for context (with external subject IDs)
+flapjack is-active-context my_feature --user user123 --subjects tenant:acme
+
+# Check multiple flags for context
+flapjack are-active-context --names my_feature other_feature --subjects tenant:acme
+
 # Update a flag
 flapjack update 1 --percent 50 --everyone false
 
@@ -355,6 +407,35 @@ flapjack update 1 --clear-roles --clear-percent
 
 # Delete a flag
 flapjack delete 1
+
+# Add/remove/list subject mappings on a flag
+flapjack add-subject 1 tenant:acme
+flapjack remove-subject 1 tenant:acme
+flapjack list-subjects 1
+flapjack list-by-subject tenant:acme
+
+# Feature flag groups
+flapjack group-create --name checkout_rollout --note "Checkout launch cohort"
+flapjack group-list
+flapjack group-get 1
+flapjack group-get-by-name checkout_rollout
+flapjack group-update 1 --note "Updated"
+flapjack group-delete 1
+
+# Group membership
+flapjack group-add-flag 1 10
+flapjack group-remove-flag 1 10
+flapjack group-list-flags 1
+flapjack group-list-for-flag 10
+
+# Bulk update all flags in a group
+flapjack group-update-all 1 --percent 25 --roles admin
+
+# Group-level subject mappings
+flapjack group-add-subject 1 tenant:acme
+flapjack group-remove-subject 1 tenant:acme
+flapjack group-list-subjects 1
+flapjack group-list-by-subject tenant:acme
 
 # Debug user bucketing
 flapjack hash-user user123

--- a/migrations/1779210257698_add-feature-flag-subjects.js
+++ b/migrations/1779210257698_add-feature-flag-subjects.js
@@ -1,0 +1,93 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const up = (pgm) => {
+  pgm.createTable(
+    { schema: "flapjack", name: "feature_flag_subject" },
+    {
+      id: "id",
+      feature_flag_id: {
+        type: "integer",
+        notNull: true,
+        references: { schema: "flapjack", name: "feature_flag" },
+        onDelete: "CASCADE",
+      },
+      subject: { type: "text", notNull: true },
+      created: {
+        type: "timestamptz",
+        notNull: true,
+        default: pgm.func("now()"),
+      },
+    },
+  );
+
+  pgm.addConstraint(
+    { schema: "flapjack", name: "feature_flag_subject" },
+    "unique_feature_flag_subject",
+    {
+      unique: ["feature_flag_id", "subject"],
+    },
+  );
+
+  pgm.createIndex(
+    { schema: "flapjack", name: "feature_flag_subject" },
+    "feature_flag_id",
+  );
+  pgm.createIndex(
+    { schema: "flapjack", name: "feature_flag_subject" },
+    "subject",
+  );
+
+  pgm.createTable(
+    { schema: "flapjack", name: "feature_flag_group_subject" },
+    {
+      id: "id",
+      feature_flag_group_id: {
+        type: "integer",
+        notNull: true,
+        references: { schema: "flapjack", name: "feature_flag_group" },
+        onDelete: "CASCADE",
+      },
+      subject: { type: "text", notNull: true },
+      created: {
+        type: "timestamptz",
+        notNull: true,
+        default: pgm.func("now()"),
+      },
+    },
+  );
+
+  pgm.addConstraint(
+    { schema: "flapjack", name: "feature_flag_group_subject" },
+    "unique_feature_flag_group_subject",
+    {
+      unique: ["feature_flag_group_id", "subject"],
+    },
+  );
+
+  pgm.createIndex(
+    { schema: "flapjack", name: "feature_flag_group_subject" },
+    "feature_flag_group_id",
+  );
+  pgm.createIndex(
+    { schema: "flapjack", name: "feature_flag_group_subject" },
+    "subject",
+  );
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const down = (pgm) => {
+  pgm.dropTable({ schema: "flapjack", name: "feature_flag_group_subject" });
+  pgm.dropTable({ schema: "flapjack", name: "feature_flag_subject" });
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clean": "rm -rf dist",
     "dev": "npx tsc --watch",
     "dev:env": "bash bin/dev/env.sh",
-    "dev:migrate": "npx dotenv-cli -e env -- node-pg-migrate up",
+    "dev:migrate": "npx dotenv-cli -e .env -- node-pg-migrate up -s flapjack --create-schema -t pgmigrations",
     "dev:docker:up": "docker compose -f docker-compose.yml up -d",
     "dev:docker:down": "docker compose -f docker-compose.yml down -v",
     "create-migration": "npx node-pg-migrate create --",

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -78,7 +78,7 @@ describe("FeatureFlagCache", () => {
   beforeEach(() => {
     // Create mock model
     mockModel = {
-      isActiveForUser: vi.fn(),
+      isActiveForContext: vi.fn(),
     } as any;
 
     // Create cache
@@ -94,7 +94,7 @@ describe("FeatureFlagCache", () => {
 
   it("should call model on cache miss", async () => {
     const mockResult = true;
-    vi.mocked(mockModel.isActiveForUser).mockResolvedValue(mockResult);
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(mockResult);
 
     const result = await flagCache.isActiveForUser({
       name: "test_flag",
@@ -102,16 +102,16 @@ describe("FeatureFlagCache", () => {
     });
 
     expect(result).toBe(mockResult);
-    expect(mockModel.isActiveForUser).toHaveBeenCalledWith({
+    expect(mockModel.isActiveForContext).toHaveBeenCalledWith({
       name: "test_flag",
       user: "user123",
     });
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(1);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(1);
   });
 
   it("should return cached result on cache hit", async () => {
     const mockResult = true;
-    vi.mocked(mockModel.isActiveForUser).mockResolvedValue(mockResult);
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(mockResult);
 
     // First call should hit the model
     const result1 = await flagCache.isActiveForUser({
@@ -127,11 +127,11 @@ describe("FeatureFlagCache", () => {
 
     expect(result1).toBe(mockResult);
     expect(result2).toBe(mockResult);
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(1);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(1);
   });
 
   it("should generate different cache keys for different parameters", async () => {
-    vi.mocked(mockModel.isActiveForUser).mockResolvedValue(true);
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(true);
 
     // Different user
     await flagCache.isActiveForUser({ name: "test_flag", user: "user1" });
@@ -166,11 +166,11 @@ describe("FeatureFlagCache", () => {
     });
 
     // Each call should be a cache miss
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(8);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(8);
   });
 
   it("should generate same cache key for same parameters regardless of order", async () => {
-    vi.mocked(mockModel.isActiveForUser).mockResolvedValue(true);
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(true);
 
     // Same parameters but different order
     await flagCache.isActiveForUser({
@@ -188,11 +188,11 @@ describe("FeatureFlagCache", () => {
     });
 
     // Should only call model once (second call hits cache)
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(1);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(1);
   });
 
   it("should handle undefined/null parameters consistently", async () => {
-    vi.mocked(mockModel.isActiveForUser).mockResolvedValue(true);
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(true);
 
     // Test various combinations of undefined parameters
     await flagCache.isActiveForUser({ name: "test_flag" });
@@ -201,11 +201,11 @@ describe("FeatureFlagCache", () => {
     await flagCache.isActiveForUser({ name: "test_flag", groups: undefined });
 
     // All should generate the same cache key
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(1);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(1);
   });
 
   it("should cache false results as well as true results", async () => {
-    vi.mocked(mockModel.isActiveForUser).mockResolvedValue(false);
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(false);
 
     const result1 = await flagCache.isActiveForUser({
       name: "test_flag",
@@ -218,11 +218,11 @@ describe("FeatureFlagCache", () => {
 
     expect(result1).toBe(false);
     expect(result2).toBe(false);
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(1);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(1);
   });
 
   it("should respect cache expiration", async () => {
-    vi.mocked(mockModel.isActiveForUser).mockResolvedValue(true);
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(true);
 
     const shortTtlCache = new FeatureFlagCache({
       model: mockModel,
@@ -236,7 +236,7 @@ describe("FeatureFlagCache", () => {
     // Second call within TTL
     await shortTtlCache.isActiveForUser({ name: "test_flag", user: "user1" });
 
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(1);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(1);
 
     // Wait for cache expiration
     await new Promise((resolve) => setTimeout(resolve, 150));
@@ -244,7 +244,22 @@ describe("FeatureFlagCache", () => {
     // Third call after expiration
     await shortTtlCache.isActiveForUser({ name: "test_flag", user: "user1" });
 
-    expect(mockModel.isActiveForUser).toHaveBeenCalledTimes(2);
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("should include subjects in cache key generation", async () => {
+    vi.mocked(mockModel.isActiveForContext).mockResolvedValue(true);
+
+    await flagCache.isActiveForContext({
+      name: "subject-flag",
+      subjects: ["tenant:acme"],
+    });
+    await flagCache.isActiveForContext({
+      name: "subject-flag",
+      subjects: ["tenant:beta"],
+    });
+
+    expect(mockModel.isActiveForContext).toHaveBeenCalledTimes(2);
   });
 
   it("should use custom TTL when provided", () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -99,11 +99,13 @@ export class FeatureFlagCache {
     user,
     roles,
     groups,
+    subjects,
   }: {
     name: string;
     user?: string;
     roles?: string[];
     groups?: string[];
+    subjects?: string[];
   }): string {
     // Create a consistent string representation of the parameters
     const keyParts = [
@@ -111,6 +113,7 @@ export class FeatureFlagCache {
       user || "",
       (roles || []).sort().join(","),
       (groups || []).sort().join(","),
+      (subjects || []).sort().join(","),
     ];
     const keyString = keyParts.join("|");
 
@@ -130,8 +133,35 @@ export class FeatureFlagCache {
     roles?: string[];
     groups?: string[];
   }): Promise<boolean> {
+    return this.isActiveForContext({
+      name,
+      user,
+      roles,
+      groups,
+    });
+  }
+
+  async isActiveForContext({
+    name,
+    user,
+    roles,
+    groups,
+    subjects,
+  }: {
+    name: string;
+    user?: string;
+    roles?: string[];
+    groups?: string[];
+    subjects?: string[];
+  }): Promise<boolean> {
     // Generate cache key
-    const cacheKey = this.generateCacheKey({ name, user, roles, groups });
+    const cacheKey = this.generateCacheKey({
+      name,
+      user,
+      roles,
+      groups,
+      subjects,
+    });
 
     // Try to get from cache first
     const cachedResult = await this.cache.get(cacheKey);
@@ -140,11 +170,12 @@ export class FeatureFlagCache {
     }
 
     // Cache miss, get from model
-    const result = await this.model.isActiveForUser({
+    const result = await this.model.isActiveForContext({
       name,
       user,
       roles,
       groups,
+      subjects,
     });
 
     // Store in cache with TTL

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -228,25 +228,14 @@ describe("CLI smoke", () => {
     );
 
     const isActiveContextRes = await runCli(
-      [
-        "is-active-context",
-        "cli-subject-flag",
-        "--subjects",
-        "tenant:acme",
-      ],
+      ["is-active-context", "cli-subject-flag", "--subjects", "tenant:acme"],
       { DATABASE_URL: TEST_DB_URL },
     );
     expect(isActiveContextRes.code).toBe(0);
     expect(JSON.parse(isActiveContextRes.stdout.trim()).isActive).toBe(true);
 
     const areActiveUserRes = await runCli(
-      [
-        "are-active",
-        "--names",
-        "cli-subject-flag",
-        "--roles",
-        "admin",
-      ],
+      ["are-active", "--names", "cli-subject-flag", "--roles", "admin"],
       { DATABASE_URL: TEST_DB_URL },
     );
     expect(areActiveUserRes.code).toBe(0);
@@ -264,7 +253,9 @@ describe("CLI smoke", () => {
       { DATABASE_URL: TEST_DB_URL },
     );
     expect(areActiveContextRes.code).toBe(0);
-    const areActiveContextPayload = JSON.parse(areActiveContextRes.stdout.trim());
+    const areActiveContextPayload = JSON.parse(
+      areActiveContextRes.stdout.trim(),
+    );
     expect(areActiveContextPayload.results["cli-subject-flag"]).toBe(true);
 
     const listBySubjectRes = await runCli(["list-by-subject", "tenant:acme"], {
@@ -309,18 +300,23 @@ describe("CLI smoke", () => {
       { DATABASE_URL: TEST_DB_URL },
     );
     expect(groupListBySubjectRes.code).toBe(0);
-    const groupListBySubjectPayload = JSON.parse(groupListBySubjectRes.stdout.trim());
+    const groupListBySubjectPayload = JSON.parse(
+      groupListBySubjectRes.stdout.trim(),
+    );
     expect(groupListBySubjectPayload.groups.map((g: any) => g.id)).toContain(
       group.id,
     );
 
-    const groupListFlagsRes = await runCli(["group-list-flags", String(group.id)], {
-      DATABASE_URL: TEST_DB_URL,
-    });
-    expect(groupListFlagsRes.code).toBe(0);
-    expect(JSON.parse(groupListFlagsRes.stdout.trim()).flags.map((f: any) => f.id)).toContain(
-      flag.id,
+    const groupListFlagsRes = await runCli(
+      ["group-list-flags", String(group.id)],
+      {
+        DATABASE_URL: TEST_DB_URL,
+      },
     );
+    expect(groupListFlagsRes.code).toBe(0);
+    expect(
+      JSON.parse(groupListFlagsRes.stdout.trim()).flags.map((f: any) => f.id),
+    ).toContain(flag.id);
 
     const groupListForFlagRes = await runCli(
       ["group-list-for-flag", String(flag.id)],
@@ -328,7 +324,9 @@ describe("CLI smoke", () => {
     );
     expect(groupListForFlagRes.code).toBe(0);
     expect(
-      JSON.parse(groupListForFlagRes.stdout.trim()).groups.map((g: any) => g.id),
+      JSON.parse(groupListForFlagRes.stdout.trim()).groups.map(
+        (g: any) => g.id,
+      ),
     ).toContain(group.id);
 
     const groupUpdateAllRes = await runCli(
@@ -336,21 +334,18 @@ describe("CLI smoke", () => {
       { DATABASE_URL: TEST_DB_URL },
     );
     expect(groupUpdateAllRes.code).toBe(0);
-    expect(JSON.parse(groupUpdateAllRes.stdout.trim()).updatedCount).toBeGreaterThan(
-      0,
-    );
+    expect(
+      JSON.parse(groupUpdateAllRes.stdout.trim()).updatedCount,
+    ).toBeGreaterThan(0);
 
     const contextAfterUpdateRes = await runCli(
-      [
-        "is-active-context",
-        "cli-subject-flag",
-        "--subjects",
-        "tenant:acme",
-      ],
+      ["is-active-context", "cli-subject-flag", "--subjects", "tenant:acme"],
       { DATABASE_URL: TEST_DB_URL },
     );
     expect(contextAfterUpdateRes.code).toBe(0);
-    expect(JSON.parse(contextAfterUpdateRes.stdout.trim()).isActive).toBe(false);
+    expect(JSON.parse(contextAfterUpdateRes.stdout.trim()).isActive).toBe(
+      false,
+    );
 
     const removeSubjectRes = await runCli(
       ["remove-subject", String(flag.id), "tenant:acme"],

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -195,4 +195,187 @@ describe("CLI smoke", () => {
       DATABASE_URL: TEST_DB_URL,
     });
   });
+
+  it("supports subject and group CLI workflows", async () => {
+    const createRes = await runCli(
+      [
+        "create",
+        "--name",
+        "cli-subject-flag",
+        "--roles",
+        "admin",
+        "--note",
+        "subject flow",
+      ],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(createRes.code).toBe(0);
+    const flag = JSON.parse(createRes.stdout.trim());
+
+    const addSubjectRes = await runCli(
+      ["add-subject", String(flag.id), "tenant:acme"],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(addSubjectRes.code).toBe(0);
+    expect(JSON.parse(addSubjectRes.stdout.trim()).added).toBe(true);
+
+    const listSubjectsRes = await runCli(["list-subjects", String(flag.id)], {
+      DATABASE_URL: TEST_DB_URL,
+    });
+    expect(listSubjectsRes.code).toBe(0);
+    expect(JSON.parse(listSubjectsRes.stdout.trim()).subjects).toContain(
+      "tenant:acme",
+    );
+
+    const isActiveContextRes = await runCli(
+      [
+        "is-active-context",
+        "cli-subject-flag",
+        "--subjects",
+        "tenant:acme",
+      ],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(isActiveContextRes.code).toBe(0);
+    expect(JSON.parse(isActiveContextRes.stdout.trim()).isActive).toBe(true);
+
+    const areActiveUserRes = await runCli(
+      [
+        "are-active",
+        "--names",
+        "cli-subject-flag",
+        "--roles",
+        "admin",
+      ],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(areActiveUserRes.code).toBe(0);
+    const areActiveUserPayload = JSON.parse(areActiveUserRes.stdout.trim());
+    expect(areActiveUserPayload.results["cli-subject-flag"]).toBe(true);
+
+    const areActiveContextRes = await runCli(
+      [
+        "are-active-context",
+        "--names",
+        "cli-subject-flag",
+        "--subjects",
+        "tenant:acme",
+      ],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(areActiveContextRes.code).toBe(0);
+    const areActiveContextPayload = JSON.parse(areActiveContextRes.stdout.trim());
+    expect(areActiveContextPayload.results["cli-subject-flag"]).toBe(true);
+
+    const listBySubjectRes = await runCli(["list-by-subject", "tenant:acme"], {
+      DATABASE_URL: TEST_DB_URL,
+    });
+    expect(listBySubjectRes.code).toBe(0);
+    const listBySubjectPayload = JSON.parse(listBySubjectRes.stdout.trim());
+    expect(listBySubjectPayload.flags.map((f: any) => f.id)).toContain(flag.id);
+
+    const groupCreateRes = await runCli(
+      ["group-create", "--name", "cli-subject-group", "--note", "group flow"],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupCreateRes.code).toBe(0);
+    const group = JSON.parse(groupCreateRes.stdout.trim());
+
+    const groupAddFlagRes = await runCli(
+      ["group-add-flag", String(group.id), String(flag.id)],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupAddFlagRes.code).toBe(0);
+    expect(JSON.parse(groupAddFlagRes.stdout.trim()).added).toBe(true);
+
+    const groupAddSubjectRes = await runCli(
+      ["group-add-subject", String(group.id), "tenant:beta"],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupAddSubjectRes.code).toBe(0);
+    expect(JSON.parse(groupAddSubjectRes.stdout.trim()).added).toBe(true);
+
+    const groupListSubjectsRes = await runCli(
+      ["group-list-subjects", String(group.id)],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupListSubjectsRes.code).toBe(0);
+    expect(JSON.parse(groupListSubjectsRes.stdout.trim()).subjects).toContain(
+      "tenant:beta",
+    );
+
+    const groupListBySubjectRes = await runCli(
+      ["group-list-by-subject", "tenant:beta"],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupListBySubjectRes.code).toBe(0);
+    const groupListBySubjectPayload = JSON.parse(groupListBySubjectRes.stdout.trim());
+    expect(groupListBySubjectPayload.groups.map((g: any) => g.id)).toContain(
+      group.id,
+    );
+
+    const groupListFlagsRes = await runCli(["group-list-flags", String(group.id)], {
+      DATABASE_URL: TEST_DB_URL,
+    });
+    expect(groupListFlagsRes.code).toBe(0);
+    expect(JSON.parse(groupListFlagsRes.stdout.trim()).flags.map((f: any) => f.id)).toContain(
+      flag.id,
+    );
+
+    const groupListForFlagRes = await runCli(
+      ["group-list-for-flag", String(flag.id)],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupListForFlagRes.code).toBe(0);
+    expect(
+      JSON.parse(groupListForFlagRes.stdout.trim()).groups.map((g: any) => g.id),
+    ).toContain(group.id);
+
+    const groupUpdateAllRes = await runCli(
+      ["group-update-all", String(group.id), "--everyone", "false"],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupUpdateAllRes.code).toBe(0);
+    expect(JSON.parse(groupUpdateAllRes.stdout.trim()).updatedCount).toBeGreaterThan(
+      0,
+    );
+
+    const contextAfterUpdateRes = await runCli(
+      [
+        "is-active-context",
+        "cli-subject-flag",
+        "--subjects",
+        "tenant:acme",
+      ],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(contextAfterUpdateRes.code).toBe(0);
+    expect(JSON.parse(contextAfterUpdateRes.stdout.trim()).isActive).toBe(false);
+
+    const removeSubjectRes = await runCli(
+      ["remove-subject", String(flag.id), "tenant:acme"],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(removeSubjectRes.code).toBe(0);
+    expect(JSON.parse(removeSubjectRes.stdout.trim()).removed).toBe(true);
+
+    const groupRemoveSubjectRes = await runCli(
+      ["group-remove-subject", String(group.id), "tenant:beta"],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupRemoveSubjectRes.code).toBe(0);
+    expect(JSON.parse(groupRemoveSubjectRes.stdout.trim()).removed).toBe(true);
+
+    const groupRemoveFlagRes = await runCli(
+      ["group-remove-flag", String(group.id), String(flag.id)],
+      { DATABASE_URL: TEST_DB_URL },
+    );
+    expect(groupRemoveFlagRes.code).toBe(0);
+    expect(JSON.parse(groupRemoveFlagRes.stdout.trim()).removed).toBe(true);
+
+    const groupDeleteRes = await runCli(["group-delete", String(group.id)], {
+      DATABASE_URL: TEST_DB_URL,
+    });
+    expect(groupDeleteRes.code).toBe(0);
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -833,23 +833,25 @@ cli.command(
   "group-update <id>",
   "Update a feature flag group",
   (yargs) => {
-    return yargs.positional("id", {
-      type: "number",
-      describe: "Feature flag group ID",
-    }).options({
-      name: {
-        type: "string",
-        describe: "Feature flag group name",
-      },
-      note: {
-        type: "string",
-        describe: "Feature flag group description",
-      },
-      "clear-note": {
-        type: "boolean",
-        describe: "Clear the group note",
-      },
-    });
+    return yargs
+      .positional("id", {
+        type: "number",
+        describe: "Feature flag group ID",
+      })
+      .options({
+        name: {
+          type: "string",
+          describe: "Feature flag group name",
+        },
+        note: {
+          type: "string",
+          describe: "Feature flag group description",
+        },
+        "clear-note": {
+          type: "boolean",
+          describe: "Clear the group note",
+        },
+      });
   },
   async (argv) => {
     const db = createDatabase();
@@ -967,7 +969,10 @@ cli.command(
     const model = new FeatureFlagGroupModel(db);
 
     try {
-      const removed = await model.removeFeatureFlag(argv.groupId!, argv.flagId!);
+      const removed = await model.removeFeatureFlag(
+        argv.groupId!,
+        argv.flagId!,
+      );
       console.log(
         JSON.stringify(
           {
@@ -1063,51 +1068,53 @@ cli.command(
   "group-update-all <groupId>",
   "Update all feature flags in a group",
   (yargs) => {
-    return yargs.positional("groupId", {
-      type: "number",
-      describe: "Feature flag group ID",
-    }).options({
-      everyone: {
-        type: "boolean",
-        describe: "Enable flag for everyone (overrides all other settings)",
-      },
-      percent: {
+    return yargs
+      .positional("groupId", {
         type: "number",
-        describe: "Percentage rollout (0-99.9)",
-      },
-      roles: {
-        type: "array",
-        describe: "List of roles that have this flag enabled",
-      },
-      groups: {
-        type: "array",
-        describe: "List of user groups that have this flag enabled",
-      },
-      users: {
-        type: "array",
-        describe: "List of specific user IDs that have this flag enabled",
-      },
-      "clear-everyone": {
-        type: "boolean",
-        describe: "Unset the everyone override",
-      },
-      "clear-percent": {
-        type: "boolean",
-        describe: "Unset percentage rollout",
-      },
-      "clear-roles": {
-        type: "boolean",
-        describe: "Clear roles list",
-      },
-      "clear-groups": {
-        type: "boolean",
-        describe: "Clear groups list",
-      },
-      "clear-users": {
-        type: "boolean",
-        describe: "Clear users list",
-      },
-    });
+        describe: "Feature flag group ID",
+      })
+      .options({
+        everyone: {
+          type: "boolean",
+          describe: "Enable flag for everyone (overrides all other settings)",
+        },
+        percent: {
+          type: "number",
+          describe: "Percentage rollout (0-99.9)",
+        },
+        roles: {
+          type: "array",
+          describe: "List of roles that have this flag enabled",
+        },
+        groups: {
+          type: "array",
+          describe: "List of user groups that have this flag enabled",
+        },
+        users: {
+          type: "array",
+          describe: "List of specific user IDs that have this flag enabled",
+        },
+        "clear-everyone": {
+          type: "boolean",
+          describe: "Unset the everyone override",
+        },
+        "clear-percent": {
+          type: "boolean",
+          describe: "Unset percentage rollout",
+        },
+        "clear-roles": {
+          type: "boolean",
+          describe: "Clear roles list",
+        },
+        "clear-groups": {
+          type: "boolean",
+          describe: "Clear groups list",
+        },
+        "clear-users": {
+          type: "boolean",
+          describe: "Clear users list",
+        },
+      });
   },
   async (argv) => {
     const db = createDatabase();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { Pool } from "pg";
-import { FeatureFlagModel } from "./model.js";
+import { FeatureFlagModel, FeatureFlagGroupModel } from "./model.js";
 import dotenv from "dotenv";
 
 dotenv.config({ quiet: true });
@@ -364,6 +364,941 @@ cli.command(
       );
     } catch (error) {
       console.error("Error checking feature flag:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Check multiple flags for user command
+cli.command(
+  "are-active",
+  "Check if multiple feature flags are active for a user",
+  (yargs) => {
+    return yargs.options({
+      names: {
+        type: "array",
+        describe: "Optional list of feature flag names (defaults to all flags)",
+      },
+      user: {
+        type: "string",
+        describe: "User ID",
+      },
+      roles: {
+        type: "array",
+        describe: "User roles",
+      },
+      groups: {
+        type: "array",
+        describe: "User groups",
+      },
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagModel(db);
+
+    try {
+      const results = await model.areActiveForUser({
+        names: argv.names as string[] | undefined,
+        user: argv.user,
+        roles: argv.roles as string[],
+        groups: argv.groups as string[],
+      });
+
+      console.log(
+        JSON.stringify(
+          {
+            names: argv.names,
+            user: argv.user,
+            roles: argv.roles,
+            groups: argv.groups,
+            results,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error checking multiple feature flags:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Check if active for context command
+cli.command(
+  "is-active-context <name>",
+  "Check if a feature flag is active for a context including subjects",
+  (yargs) => {
+    return yargs
+      .positional("name", {
+        type: "string",
+        describe: "Feature flag name",
+      })
+      .options({
+        user: {
+          type: "string",
+          describe: "User ID",
+        },
+        roles: {
+          type: "array",
+          describe: "User roles",
+        },
+        groups: {
+          type: "array",
+          describe: "User groups",
+        },
+        subjects: {
+          type: "array",
+          describe: "External subject IDs (for example tenant:acme)",
+        },
+      });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagModel(db);
+
+    try {
+      const isActive = await model.isActiveForContext({
+        name: argv.name!,
+        user: argv.user,
+        roles: argv.roles as string[],
+        groups: argv.groups as string[],
+        subjects: argv.subjects as string[],
+      });
+
+      console.log(
+        JSON.stringify(
+          {
+            name: argv.name,
+            isActive,
+            user: argv.user,
+            roles: argv.roles,
+            groups: argv.groups,
+            subjects: argv.subjects,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error checking feature flag context:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Add a subject to a feature flag
+cli.command(
+  "add-subject <id> <subject>",
+  "Add an external subject ID to a feature flag",
+  (yargs) => {
+    return yargs
+      .positional("id", {
+        type: "number",
+        describe: "Feature flag ID",
+      })
+      .positional("subject", {
+        type: "string",
+        describe: "External subject ID (for example tenant:acme)",
+      });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagModel(db);
+
+    try {
+      const added = await model.addSubject(argv.id!, argv.subject!);
+      console.log(
+        JSON.stringify(
+          {
+            id: argv.id,
+            subject: argv.subject,
+            added,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error adding subject:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Remove a subject from a feature flag
+cli.command(
+  "remove-subject <id> <subject>",
+  "Remove an external subject ID from a feature flag",
+  (yargs) => {
+    return yargs
+      .positional("id", {
+        type: "number",
+        describe: "Feature flag ID",
+      })
+      .positional("subject", {
+        type: "string",
+        describe: "External subject ID",
+      });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagModel(db);
+
+    try {
+      const removed = await model.removeSubject(argv.id!, argv.subject!);
+      console.log(
+        JSON.stringify(
+          {
+            id: argv.id,
+            subject: argv.subject,
+            removed,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error removing subject:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// List subjects for a feature flag
+cli.command(
+  "list-subjects <id>",
+  "List external subject IDs for a feature flag",
+  (yargs) => {
+    return yargs.positional("id", {
+      type: "number",
+      describe: "Feature flag ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagModel(db);
+
+    try {
+      const subjects = await model.getSubjects(argv.id!);
+      console.log(
+        JSON.stringify(
+          {
+            id: argv.id,
+            subjects,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error listing subjects:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Check multiple flags for context command
+cli.command(
+  "are-active-context",
+  "Check if multiple feature flags are active for a context including subjects",
+  (yargs) => {
+    return yargs.options({
+      names: {
+        type: "array",
+        describe: "Optional list of feature flag names (defaults to all flags)",
+      },
+      user: {
+        type: "string",
+        describe: "User ID",
+      },
+      roles: {
+        type: "array",
+        describe: "User roles",
+      },
+      groups: {
+        type: "array",
+        describe: "User groups",
+      },
+      subjects: {
+        type: "array",
+        describe: "External subject IDs (for example tenant:acme)",
+      },
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagModel(db);
+
+    try {
+      const results = await model.areActiveForContext({
+        names: argv.names as string[] | undefined,
+        user: argv.user,
+        roles: argv.roles as string[],
+        groups: argv.groups as string[],
+        subjects: argv.subjects as string[],
+      });
+
+      console.log(
+        JSON.stringify(
+          {
+            names: argv.names,
+            user: argv.user,
+            roles: argv.roles,
+            groups: argv.groups,
+            subjects: argv.subjects,
+            results,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error checking multiple feature flag contexts:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// List flags that directly match a subject
+cli.command(
+  "list-by-subject <subject>",
+  "List feature flags directly assigned to an external subject ID",
+  (yargs) => {
+    return yargs.positional("subject", {
+      type: "string",
+      describe: "External subject ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagModel(db);
+
+    try {
+      const flags = await model.getFeatureFlagsForSubject(argv.subject!);
+      console.log(
+        JSON.stringify(
+          {
+            subject: argv.subject,
+            flags,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error listing flags by subject:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Create feature flag group command
+cli.command(
+  "group-create",
+  "Create a feature flag group",
+  (yargs) => {
+    return yargs
+      .options({
+        name: {
+          type: "string",
+          describe: "Feature flag group name",
+        },
+        note: {
+          type: "string",
+          describe: "Feature flag group description",
+        },
+      })
+      .demandOption("name", "Feature flag group name is required");
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const group = await model.create({
+        name: argv.name!,
+        note: argv.note,
+      });
+      console.log(JSON.stringify(group, null, 2));
+    } catch (error) {
+      console.error("Error creating feature flag group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// List feature flag groups command
+cli.command(
+  "group-list",
+  "List all feature flag groups",
+  () => {},
+  async () => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const groups = await model.list();
+      console.log(JSON.stringify(groups, null, 2));
+    } catch (error) {
+      console.error("Error listing feature flag groups:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Get feature flag group by ID command
+cli.command(
+  "group-get <id>",
+  "Get a feature flag group by ID",
+  (yargs) => {
+    return yargs.positional("id", {
+      type: "number",
+      describe: "Feature flag group ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const group = await model.getById(argv.id!);
+      if (!group) {
+        console.log(`Feature flag group with ID ${argv.id} not found`);
+        process.exit(1);
+      }
+      console.log(JSON.stringify(group, null, 2));
+    } catch (error) {
+      console.error("Error getting feature flag group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Get feature flag group by name command
+cli.command(
+  "group-get-by-name <name>",
+  "Get a feature flag group by name",
+  (yargs) => {
+    return yargs.positional("name", {
+      type: "string",
+      describe: "Feature flag group name",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const group = await model.getByName(argv.name!);
+      if (!group) {
+        console.log(`Feature flag group with name "${argv.name}" not found`);
+        process.exit(1);
+      }
+      console.log(JSON.stringify(group, null, 2));
+    } catch (error) {
+      console.error("Error getting feature flag group by name:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Update feature flag group command
+cli.command(
+  "group-update <id>",
+  "Update a feature flag group",
+  (yargs) => {
+    return yargs.positional("id", {
+      type: "number",
+      describe: "Feature flag group ID",
+    }).options({
+      name: {
+        type: "string",
+        describe: "Feature flag group name",
+      },
+      note: {
+        type: "string",
+        describe: "Feature flag group description",
+      },
+      "clear-note": {
+        type: "boolean",
+        describe: "Clear the group note",
+      },
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const changes: any = {};
+      if (argv.name !== undefined) changes.name = argv.name;
+      if ((argv as any).clearNote) changes.note = null;
+      else if (argv.note !== undefined) changes.note = argv.note;
+
+      const group = await model.update(argv.id!, changes);
+      if (!group) {
+        console.log(`Feature flag group with ID ${argv.id} not found`);
+        process.exit(1);
+      }
+      console.log(JSON.stringify(group, null, 2));
+    } catch (error) {
+      console.error("Error updating feature flag group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Delete feature flag group command
+cli.command(
+  "group-delete <id>",
+  "Delete a feature flag group",
+  (yargs) => {
+    return yargs.positional("id", {
+      type: "number",
+      describe: "Feature flag group ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const deleted = await model.delete(argv.id!);
+      if (!deleted) {
+        console.log(`Feature flag group with ID ${argv.id} not found`);
+        process.exit(1);
+      }
+      console.log(`Feature flag group with ID ${argv.id} deleted successfully`);
+    } catch (error) {
+      console.error("Error deleting feature flag group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Add flag to feature flag group command
+cli.command(
+  "group-add-flag <groupId> <flagId>",
+  "Add a feature flag to a group",
+  (yargs) => {
+    return yargs
+      .positional("groupId", {
+        type: "number",
+        describe: "Feature flag group ID",
+      })
+      .positional("flagId", {
+        type: "number",
+        describe: "Feature flag ID",
+      });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const added = await model.addFeatureFlag(argv.groupId!, argv.flagId!);
+      console.log(
+        JSON.stringify(
+          {
+            groupId: argv.groupId,
+            flagId: argv.flagId,
+            added,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error adding feature flag to group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Remove flag from feature flag group command
+cli.command(
+  "group-remove-flag <groupId> <flagId>",
+  "Remove a feature flag from a group",
+  (yargs) => {
+    return yargs
+      .positional("groupId", {
+        type: "number",
+        describe: "Feature flag group ID",
+      })
+      .positional("flagId", {
+        type: "number",
+        describe: "Feature flag ID",
+      });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const removed = await model.removeFeatureFlag(argv.groupId!, argv.flagId!);
+      console.log(
+        JSON.stringify(
+          {
+            groupId: argv.groupId,
+            flagId: argv.flagId,
+            removed,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error removing feature flag from group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// List flags in feature flag group command
+cli.command(
+  "group-list-flags <groupId>",
+  "List all feature flags in a group",
+  (yargs) => {
+    return yargs.positional("groupId", {
+      type: "number",
+      describe: "Feature flag group ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const flags = await model.getFeatureFlags(argv.groupId!);
+      console.log(
+        JSON.stringify(
+          {
+            groupId: argv.groupId,
+            flags,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error listing flags for group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// List groups for feature flag command
+cli.command(
+  "group-list-for-flag <flagId>",
+  "List all groups that contain a feature flag",
+  (yargs) => {
+    return yargs.positional("flagId", {
+      type: "number",
+      describe: "Feature flag ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const groups = await model.getGroupsForFeatureFlag(argv.flagId!);
+      console.log(
+        JSON.stringify(
+          {
+            flagId: argv.flagId,
+            groups,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error listing groups for feature flag:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Bulk update flags in a group command
+cli.command(
+  "group-update-all <groupId>",
+  "Update all feature flags in a group",
+  (yargs) => {
+    return yargs.positional("groupId", {
+      type: "number",
+      describe: "Feature flag group ID",
+    }).options({
+      everyone: {
+        type: "boolean",
+        describe: "Enable flag for everyone (overrides all other settings)",
+      },
+      percent: {
+        type: "number",
+        describe: "Percentage rollout (0-99.9)",
+      },
+      roles: {
+        type: "array",
+        describe: "List of roles that have this flag enabled",
+      },
+      groups: {
+        type: "array",
+        describe: "List of user groups that have this flag enabled",
+      },
+      users: {
+        type: "array",
+        describe: "List of specific user IDs that have this flag enabled",
+      },
+      "clear-everyone": {
+        type: "boolean",
+        describe: "Unset the everyone override",
+      },
+      "clear-percent": {
+        type: "boolean",
+        describe: "Unset percentage rollout",
+      },
+      "clear-roles": {
+        type: "boolean",
+        describe: "Clear roles list",
+      },
+      "clear-groups": {
+        type: "boolean",
+        describe: "Clear groups list",
+      },
+      "clear-users": {
+        type: "boolean",
+        describe: "Clear users list",
+      },
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const changes: any = {};
+
+      if ((argv as any).clearEveryone) changes.everyone = null;
+      else if (argv.everyone !== undefined) changes.everyone = argv.everyone;
+
+      if ((argv as any).clearPercent) changes.percent = null;
+      else if (argv.percent !== undefined) changes.percent = argv.percent;
+
+      if ((argv as any).clearRoles) changes.roles = null;
+      else if (argv.roles !== undefined) changes.roles = argv.roles as string[];
+
+      if ((argv as any).clearGroups) changes.groups = null;
+      else if (argv.groups !== undefined)
+        changes.groups = argv.groups as string[];
+
+      if ((argv as any).clearUsers) changes.users = null;
+      else if (argv.users !== undefined) changes.users = argv.users as string[];
+
+      const updatedCount = await model.updateAll(argv.groupId!, changes);
+
+      console.log(
+        JSON.stringify(
+          {
+            groupId: argv.groupId,
+            updatedCount,
+            changes,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error updating all flags in group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Add subject to feature flag group command
+cli.command(
+  "group-add-subject <groupId> <subject>",
+  "Add an external subject ID to a feature flag group",
+  (yargs) => {
+    return yargs
+      .positional("groupId", {
+        type: "number",
+        describe: "Feature flag group ID",
+      })
+      .positional("subject", {
+        type: "string",
+        describe: "External subject ID",
+      });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const added = await model.addSubject(argv.groupId!, argv.subject!);
+      console.log(
+        JSON.stringify(
+          {
+            groupId: argv.groupId,
+            subject: argv.subject,
+            added,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error adding subject to group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// Remove subject from feature flag group command
+cli.command(
+  "group-remove-subject <groupId> <subject>",
+  "Remove an external subject ID from a feature flag group",
+  (yargs) => {
+    return yargs
+      .positional("groupId", {
+        type: "number",
+        describe: "Feature flag group ID",
+      })
+      .positional("subject", {
+        type: "string",
+        describe: "External subject ID",
+      });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const removed = await model.removeSubject(argv.groupId!, argv.subject!);
+      console.log(
+        JSON.stringify(
+          {
+            groupId: argv.groupId,
+            subject: argv.subject,
+            removed,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error removing subject from group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// List subjects for feature flag group command
+cli.command(
+  "group-list-subjects <groupId>",
+  "List external subject IDs for a feature flag group",
+  (yargs) => {
+    return yargs.positional("groupId", {
+      type: "number",
+      describe: "Feature flag group ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const subjects = await model.getSubjects(argv.groupId!);
+      console.log(
+        JSON.stringify(
+          {
+            groupId: argv.groupId,
+            subjects,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error listing subjects for group:", error);
+      process.exit(1);
+    } finally {
+      await db.end();
+    }
+  },
+);
+
+// List groups for subject command
+cli.command(
+  "group-list-by-subject <subject>",
+  "List feature flag groups assigned to an external subject ID",
+  (yargs) => {
+    return yargs.positional("subject", {
+      type: "string",
+      describe: "External subject ID",
+    });
+  },
+  async (argv) => {
+    const db = createDatabase();
+    const model = new FeatureFlagGroupModel(db);
+
+    try {
+      const groups = await model.getGroupsForSubject(argv.subject!);
+      console.log(
+        JSON.stringify(
+          {
+            subject: argv.subject,
+            groups,
+          },
+          null,
+          2,
+        ),
+      );
+    } catch (error) {
+      console.error("Error listing groups by subject:", error);
       process.exit(1);
     } finally {
       await db.end();

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -466,6 +466,20 @@ describe("FeatureFlagModel", () => {
       const deleted = await model.delete(99999);
       expect(deleted).toBe(false);
     });
+
+    it("should cascade delete subject mappings for a feature flag", async () => {
+      const created = await model.create({ name: "test-delete-subject-cascade" });
+      await model.addSubject(created.id, "tenant:delete-cascade");
+
+      const beforeDelete = await model.getSubjects(created.id);
+      expect(beforeDelete).toContain("tenant:delete-cascade");
+
+      const deleted = await model.delete(created.id);
+      expect(deleted).toBe(true);
+
+      const afterDelete = await model.getSubjects(created.id);
+      expect(afterDelete).toEqual([]);
+    });
   });
 
   describe("getLastModified", () => {
@@ -934,6 +948,105 @@ describe("FeatureFlagModel", () => {
 
       // Default behavior: expired flags are not active
       expect(isActive).toBe(true); // Should continue with normal evaluation
+    });
+
+    it("should keep everyone false as highest precedence over subjects", async () => {
+      const flag = await model.create({
+        name: "subject-precedence-everyone-false",
+        everyone: false,
+        users: ["subject-user"],
+        roles: ["admin"],
+        groups: ["beta"],
+        percent: 99.9,
+      });
+      await model.addSubject(flag.id, "tenant:override");
+
+      const isActive = await model.isActiveForContext({
+        name: "subject-precedence-everyone-false",
+        user: "subject-user",
+        roles: ["admin"],
+        groups: ["beta"],
+        subjects: ["tenant:override"],
+      });
+
+      expect(isActive).toBe(false);
+    });
+
+    it("should prioritize user match over subject match", async () => {
+      const flag = await model.create({
+        name: "subject-precedence-user",
+        users: ["user-priority-subject"],
+      });
+      await model.addSubject(flag.id, "tenant:user-priority");
+
+      const fromUserOnly = await model.isActiveForContext({
+        name: "subject-precedence-user",
+        user: "user-priority-subject",
+      });
+      const fromSubjectOnly = await model.isActiveForContext({
+        name: "subject-precedence-user",
+        subjects: ["tenant:user-priority"],
+      });
+
+      expect(fromUserOnly).toBe(true);
+      expect(fromSubjectOnly).toBe(true);
+    });
+
+    it("should prioritize subject match over groups roles and percent", async () => {
+      const flag = await model.create({
+        name: "subject-precedence-over-group-role-percent",
+        groups: ["subject-required-group"],
+        roles: ["subject-required-role"],
+        percent: 0.1,
+      });
+      await model.addSubject(flag.id, "tenant:subject-priority");
+
+      const isActive = await model.isActiveForContext({
+        name: "subject-precedence-over-group-role-percent",
+        user: "subject-priority-user",
+        roles: ["non-matching-role"],
+        groups: ["non-matching-group"],
+        subjects: ["tenant:subject-priority"],
+      });
+
+      expect(isActive).toBe(true);
+    });
+
+    it("should treat subject identifiers as case-sensitive", async () => {
+      const flag = await model.create({ name: "subject-case-sensitive" });
+      await model.addSubject(flag.id, "Tenant:CaseSensitive");
+
+      const exact = await model.isActiveForContext({
+        name: "subject-case-sensitive",
+        subjects: ["Tenant:CaseSensitive"],
+      });
+      const differentCase = await model.isActiveForContext({
+        name: "subject-case-sensitive",
+        subjects: ["tenant:casesensitive"],
+      });
+
+      expect(exact).toBe(true);
+      expect(differentCase).toBe(false);
+    });
+
+    it("should treat empty subjects as no-op and preserve legacy behavior", async () => {
+      await model.create({
+        name: "subject-empty-array-compat",
+        roles: ["admin"],
+      });
+
+      const withUndefinedSubjects = await model.isActiveForContext({
+        name: "subject-empty-array-compat",
+        roles: ["admin"],
+      });
+      const withEmptySubjects = await model.isActiveForContext({
+        name: "subject-empty-array-compat",
+        roles: ["admin"],
+        subjects: [],
+      });
+
+      expect(withUndefinedSubjects).toBe(true);
+      expect(withEmptySubjects).toBe(true);
     });
   });
 
@@ -1538,6 +1651,120 @@ describe("FeatureFlagModel", () => {
       expect(results["all-expired-continue"]).toBe(true); // Handler undefined, role matches
       expect(results["all-not-expired"]).toBe(true); // Not expired, everyone true
     });
+
+    it("should activate a flag by direct subject match", async () => {
+      const flag = await model.create({
+        name: "subject-direct-match",
+      });
+      await model.addSubject(flag.id, "tenant:acme");
+
+      const enabled = await model.isActiveForContext({
+        name: "subject-direct-match",
+        subjects: ["tenant:acme"],
+      });
+
+      expect(enabled).toBe(true);
+    });
+
+    it("should activate a flag by subject match through flag group", async () => {
+      const groupModel = new FeatureFlagGroupModel(testPool);
+      const group = await groupModel.create({
+        name: "subject-group-match-group",
+      });
+      const flag = await model.create({
+        name: "subject-group-match-flag",
+      });
+      await groupModel.addFeatureFlag(group.id, flag.id);
+      await groupModel.addSubject(group.id, "tenant:beta");
+
+      const enabled = await model.isActiveForContext({
+        name: "subject-group-match-flag",
+        subjects: ["tenant:beta"],
+      });
+
+      expect(enabled).toBe(true);
+    });
+
+    it("should keep user API parity with context API", async () => {
+      await model.create({ name: "context-parity", users: ["parity-user"] });
+
+      const fromUser = await model.isActiveForUser({
+        name: "context-parity",
+        user: "parity-user",
+      });
+      const fromContext = await model.isActiveForContext({
+        name: "context-parity",
+        user: "parity-user",
+      });
+
+      expect(fromUser).toBe(fromContext);
+    });
+
+    it("should check multiple flags with subjects", async () => {
+      const on = await model.create({ name: "context-multi-on" });
+      await model.create({ name: "context-multi-off" });
+      await model.addSubject(on.id, "tenant:gamma");
+
+      const results = await model.areActiveForContext({
+        names: ["context-multi-on", "context-multi-off"],
+        subjects: ["tenant:gamma"],
+      });
+
+      expect(results).toEqual({
+        "context-multi-on": true,
+        "context-multi-off": false,
+      });
+    });
+
+    it("should return false for missing names in areActiveForContext", async () => {
+      await model.create({ name: "context-existing-name", everyone: true });
+
+      const results = await model.areActiveForContext({
+        names: ["context-existing-name", "context-missing-name"],
+        subjects: ["tenant:any"],
+      });
+
+      expect(results).toEqual({
+        "context-existing-name": true,
+        "context-missing-name": false,
+      });
+    });
+
+    it("should preserve backwards compatibility between areActiveForUser and areActiveForContext", async () => {
+      await model.create({ name: "context-compat-1", everyone: true });
+      await model.create({ name: "context-compat-2", roles: ["admin"] });
+
+      const params = {
+        names: ["context-compat-1", "context-compat-2"],
+        user: "compat-user",
+        roles: ["admin"],
+        groups: ["beta"],
+      };
+
+      const fromUserApi = await model.areActiveForUser(params);
+      const fromContextApi = await model.areActiveForContext(params);
+
+      expect(fromUserApi).toEqual(fromContextApi);
+    });
+
+    it("should resolve subject matches from both direct and group mappings", async () => {
+      const directFlag = await model.create({ name: "subject-both-direct" });
+      const groupedFlag = await model.create({ name: "subject-both-grouped" });
+      await model.addSubject(directFlag.id, "tenant:both");
+
+      const groupModel = new FeatureFlagGroupModel(testPool);
+      const group = await groupModel.create({ name: "subject-both-group" });
+      await groupModel.addFeatureFlag(group.id, groupedFlag.id);
+      await groupModel.addSubject(group.id, "tenant:both");
+
+      const results = await model.areActiveForContext({
+        names: ["subject-both-direct", "subject-both-grouped"],
+        subjects: ["tenant:both"],
+      });
+
+      expect(results["subject-both-direct"]).toBe(true);
+      expect(results["subject-both-grouped"]).toBe(true);
+    });
   });
 });
 
@@ -1760,6 +1987,22 @@ describe("FeatureFlagGroupModel", () => {
       const flags = await groupModel.getFeatureFlags(group.id);
       expect(flags).toHaveLength(0);
     });
+
+    it("should cascade delete group subject mappings", async () => {
+      const group = await groupModel.create({
+        name: "delete-cascade-group-subjects",
+      });
+      await groupModel.addSubject(group.id, "tenant:group-delete");
+
+      const beforeDelete = await groupModel.getSubjects(group.id);
+      expect(beforeDelete).toContain("tenant:group-delete");
+
+      const deleted = await groupModel.delete(group.id);
+      expect(deleted).toBe(true);
+
+      const afterDelete = await groupModel.getSubjects(group.id);
+      expect(afterDelete).toEqual([]);
+    });
   });
 
   describe("addFeatureFlag", () => {
@@ -1950,6 +2193,91 @@ describe("FeatureFlagGroupModel", () => {
           groups[i].created.getTime(),
         );
       }
+    });
+  });
+
+  describe("subject mappings", () => {
+    it("should add and remove subjects for a group", async () => {
+      const group = await groupModel.create({ name: "group-subject-add-remove" });
+
+      const added = await groupModel.addSubject(group.id, "tenant:acme");
+      expect(added).toBe(true);
+
+      const duplicate = await groupModel.addSubject(group.id, "tenant:acme");
+      expect(duplicate).toBe(false);
+
+      const subjects = await groupModel.getSubjects(group.id);
+      expect(subjects).toContain("tenant:acme");
+
+      const removed = await groupModel.removeSubject(group.id, "tenant:acme");
+      expect(removed).toBe(true);
+
+      const removedAgain = await groupModel.removeSubject(group.id, "tenant:acme");
+      expect(removedAgain).toBe(false);
+    });
+
+    it("should list groups for a subject", async () => {
+      const group1 = await groupModel.create({ name: "group-subject-list-1" });
+      const group2 = await groupModel.create({ name: "group-subject-list-2" });
+      await groupModel.addSubject(group1.id, "tenant:list");
+      await groupModel.addSubject(group2.id, "tenant:list");
+
+      const groups = await groupModel.getGroupsForSubject("tenant:list");
+      const names = groups.map((g) => g.name);
+
+      expect(names).toContain("group-subject-list-1");
+      expect(names).toContain("group-subject-list-2");
+    });
+
+    it("should return empty arrays when no subject mappings exist", async () => {
+      const group = await groupModel.create({ name: "group-subject-empty-list" });
+      const flag = await flagModel.create({ name: "flag-subject-empty-list" });
+
+      const groupSubjects = await groupModel.getSubjects(group.id);
+      const flagSubjects = await flagModel.getSubjects(flag.id);
+      const groups = await groupModel.getGroupsForSubject("tenant:no-match");
+      const flags = await flagModel.getFeatureFlagsForSubject("tenant:no-match");
+
+      expect(groupSubjects).toEqual([]);
+      expect(flagSubjects).toEqual([]);
+      expect(groups).toEqual([]);
+      expect(flags).toEqual([]);
+    });
+
+    it("should reject subject assignment for missing entities", async () => {
+      await expect(flagModel.addSubject(9999999, "tenant:missing-flag")).rejects.toThrow();
+      await expect(
+        groupModel.addSubject(9999999, "tenant:missing-group"),
+      ).rejects.toThrow();
+    });
+
+    it("should add and remove subjects for a flag", async () => {
+      const flag = await flagModel.create({ name: "flag-subject-add-remove" });
+
+      const added = await flagModel.addSubject(flag.id, "tenant:direct");
+      expect(added).toBe(true);
+
+      const duplicate = await flagModel.addSubject(flag.id, "tenant:direct");
+      expect(duplicate).toBe(false);
+
+      const subjects = await flagModel.getSubjects(flag.id);
+      expect(subjects).toContain("tenant:direct");
+
+      const removed = await flagModel.removeSubject(flag.id, "tenant:direct");
+      expect(removed).toBe(true);
+    });
+
+    it("should list flags for a subject", async () => {
+      const flag1 = await flagModel.create({ name: "flag-for-subject-1" });
+      const flag2 = await flagModel.create({ name: "flag-for-subject-2" });
+      await flagModel.addSubject(flag1.id, "tenant:flags");
+      await flagModel.addSubject(flag2.id, "tenant:flags");
+
+      const flags = await flagModel.getFeatureFlagsForSubject("tenant:flags");
+      const names = flags.map((f) => f.name);
+
+      expect(names).toContain("flag-for-subject-1");
+      expect(names).toContain("flag-for-subject-2");
     });
   });
 

--- a/src/model.test.ts
+++ b/src/model.test.ts
@@ -468,7 +468,9 @@ describe("FeatureFlagModel", () => {
     });
 
     it("should cascade delete subject mappings for a feature flag", async () => {
-      const created = await model.create({ name: "test-delete-subject-cascade" });
+      const created = await model.create({
+        name: "test-delete-subject-cascade",
+      });
       await model.addSubject(created.id, "tenant:delete-cascade");
 
       const beforeDelete = await model.getSubjects(created.id);
@@ -2198,7 +2200,9 @@ describe("FeatureFlagGroupModel", () => {
 
   describe("subject mappings", () => {
     it("should add and remove subjects for a group", async () => {
-      const group = await groupModel.create({ name: "group-subject-add-remove" });
+      const group = await groupModel.create({
+        name: "group-subject-add-remove",
+      });
 
       const added = await groupModel.addSubject(group.id, "tenant:acme");
       expect(added).toBe(true);
@@ -2212,7 +2216,10 @@ describe("FeatureFlagGroupModel", () => {
       const removed = await groupModel.removeSubject(group.id, "tenant:acme");
       expect(removed).toBe(true);
 
-      const removedAgain = await groupModel.removeSubject(group.id, "tenant:acme");
+      const removedAgain = await groupModel.removeSubject(
+        group.id,
+        "tenant:acme",
+      );
       expect(removedAgain).toBe(false);
     });
 
@@ -2230,13 +2237,16 @@ describe("FeatureFlagGroupModel", () => {
     });
 
     it("should return empty arrays when no subject mappings exist", async () => {
-      const group = await groupModel.create({ name: "group-subject-empty-list" });
+      const group = await groupModel.create({
+        name: "group-subject-empty-list",
+      });
       const flag = await flagModel.create({ name: "flag-subject-empty-list" });
 
       const groupSubjects = await groupModel.getSubjects(group.id);
       const flagSubjects = await flagModel.getSubjects(flag.id);
       const groups = await groupModel.getGroupsForSubject("tenant:no-match");
-      const flags = await flagModel.getFeatureFlagsForSubject("tenant:no-match");
+      const flags =
+        await flagModel.getFeatureFlagsForSubject("tenant:no-match");
 
       expect(groupSubjects).toEqual([]);
       expect(flagSubjects).toEqual([]);
@@ -2245,7 +2255,9 @@ describe("FeatureFlagGroupModel", () => {
     });
 
     it("should reject subject assignment for missing entities", async () => {
-      await expect(flagModel.addSubject(9999999, "tenant:missing-flag")).rejects.toThrow();
+      await expect(
+        flagModel.addSubject(9999999, "tenant:missing-flag"),
+      ).rejects.toThrow();
       await expect(
         groupModel.addSubject(9999999, "tenant:missing-group"),
       ).rejects.toThrow();

--- a/src/model.ts
+++ b/src/model.ts
@@ -368,7 +368,10 @@ export class FeatureFlagModel {
   /**
    * Removes an external subject identifier from a feature flag.
    */
-  async removeSubject(featureFlagId: number, subject: string): Promise<boolean> {
+  async removeSubject(
+    featureFlagId: number,
+    subject: string,
+  ): Promise<boolean> {
     const sql = `DELETE FROM ${SUBJECT_TABLE} WHERE feature_flag_id = $1 AND subject = $2`;
     const res = await this.db.query(sql, [featureFlagId, subject]);
     return (res as any).rowCount > 0;
@@ -398,7 +401,9 @@ export class FeatureFlagModel {
     return res.rows.map(mapRow);
   }
 
-  private async getSubjectMatchedFlagIds(subjects: string[] = []): Promise<Set<number>> {
+  private async getSubjectMatchedFlagIds(
+    subjects: string[] = [],
+  ): Promise<Set<number>> {
     if (subjects.length === 0) {
       return new Set<number>();
     }

--- a/src/model.ts
+++ b/src/model.ts
@@ -12,6 +12,8 @@ interface Queryable {
 }
 
 const TABLE = "flapjack.feature_flag";
+const SUBJECT_TABLE = "flapjack.feature_flag_subject";
+const GROUP_SUBJECT_TABLE = "flapjack.feature_flag_group_subject";
 
 const COLUMNS = [
   "id",
@@ -348,6 +350,74 @@ export class FeatureFlagModel {
   }
 
   /**
+   * Adds an external subject identifier to a feature flag.
+   */
+  async addSubject(featureFlagId: number, subject: string): Promise<boolean> {
+    try {
+      const sql = `INSERT INTO ${SUBJECT_TABLE} (feature_flag_id, subject) VALUES ($1, $2)`;
+      await this.db.query(sql, [featureFlagId, subject]);
+      return true;
+    } catch (err: any) {
+      if (err.code === "23505") {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Removes an external subject identifier from a feature flag.
+   */
+  async removeSubject(featureFlagId: number, subject: string): Promise<boolean> {
+    const sql = `DELETE FROM ${SUBJECT_TABLE} WHERE feature_flag_id = $1 AND subject = $2`;
+    const res = await this.db.query(sql, [featureFlagId, subject]);
+    return (res as any).rowCount > 0;
+  }
+
+  /**
+   * Gets all external subject identifiers associated with a feature flag.
+   */
+  async getSubjects(featureFlagId: number): Promise<string[]> {
+    const sql = `SELECT subject FROM ${SUBJECT_TABLE} WHERE feature_flag_id = $1 ORDER BY created DESC`;
+    const res = await this.db.query(sql, [featureFlagId]);
+    return res.rows.map((row: any) => row.subject as string);
+  }
+
+  /**
+   * Gets all feature flags directly associated with an external subject identifier.
+   */
+  async getFeatureFlagsForSubject(subject: string): Promise<FeatureFlag[]> {
+    const sql = `
+      SELECT ${COLUMNS.map((c) => `f.${c}`).join(", ")}
+      FROM ${TABLE} f
+      INNER JOIN ${SUBJECT_TABLE} s ON f.id = s.feature_flag_id
+      WHERE s.subject = $1
+      ORDER BY f.created DESC
+    `;
+    const res = await this.db.query(sql, [subject]);
+    return res.rows.map(mapRow);
+  }
+
+  private async getSubjectMatchedFlagIds(subjects: string[] = []): Promise<Set<number>> {
+    if (subjects.length === 0) {
+      return new Set<number>();
+    }
+
+    const sql = `
+      SELECT s.feature_flag_id AS feature_flag_id
+      FROM ${SUBJECT_TABLE} s
+      WHERE s.subject = ANY($1)
+      UNION
+      SELECT gm.feature_flag_id AS feature_flag_id
+      FROM ${GROUP_SUBJECT_TABLE} gs
+      INNER JOIN ${GROUP_MEMBER_TABLE} gm ON gs.feature_flag_group_id = gm.group_id
+      WHERE gs.subject = ANY($1)
+    `;
+    const res = await this.db.query(sql, [subjects]);
+    return new Set(res.rows.map((row: any) => Number(row.feature_flag_id)));
+  }
+
+  /**
    * Checks if a user belongs to any of the specified groups
    */
   private isActiveForGroups(
@@ -368,10 +438,14 @@ export class FeatureFlagModel {
       user,
       roles,
       groups,
+      subjects,
+      subjectMatchedFlagIds,
     }: {
       user?: string;
       roles?: string[];
       groups?: string[];
+      subjects?: string[];
+      subjectMatchedFlagIds?: Set<number>;
     },
   ): Promise<boolean> {
     // Everyone Override: If everyone is true or false, return that value immediately
@@ -382,6 +456,22 @@ export class FeatureFlagModel {
     // User-Specific Check: If user ID is in the users array, return true
     if (user && flag.users && flag.users.includes(user)) {
       return true;
+    }
+
+    // Subject Check: If any external subject maps to this flag directly or via group, return true
+    if (subjects && subjects.length > 0) {
+      let isSubjectMatched = false;
+
+      if (subjectMatchedFlagIds) {
+        isSubjectMatched = subjectMatchedFlagIds.has(flag.id);
+      } else {
+        const matchedFlagIds = await this.getSubjectMatchedFlagIds(subjects);
+        isSubjectMatched = matchedFlagIds.has(flag.id);
+      }
+
+      if (isSubjectMatched) {
+        return true;
+      }
     }
 
     // Group Check: If any of the user's groups match any group in the groups array, return true
@@ -481,6 +571,30 @@ export class FeatureFlagModel {
     roles?: string[];
     groups?: string[];
   }): Promise<boolean> {
+    return this.isActiveForContext({
+      name,
+      user,
+      roles,
+      groups,
+    });
+  }
+
+  /**
+   * Checks if a feature flag is active for a context, including optional external subjects.
+   */
+  async isActiveForContext({
+    name,
+    user,
+    roles,
+    groups,
+    subjects,
+  }: {
+    name: string;
+    user?: string;
+    roles?: string[];
+    groups?: string[];
+    subjects?: string[];
+  }): Promise<boolean> {
     const flag = await this.getByName(name);
 
     // No such flag
@@ -501,7 +615,14 @@ export class FeatureFlagModel {
       }
     }
 
-    return this.evaluateFlagForUser(flag, { user, roles, groups });
+    const subjectMatchedFlagIds = await this.getSubjectMatchedFlagIds(subjects);
+    return this.evaluateFlagForUser(flag, {
+      user,
+      roles,
+      groups,
+      subjects,
+      subjectMatchedFlagIds,
+    });
   }
 
   /**
@@ -562,6 +683,30 @@ export class FeatureFlagModel {
     roles?: string[];
     groups?: string[];
   }): Promise<Record<string, boolean>> {
+    return this.areActiveForContext({
+      names,
+      user,
+      roles,
+      groups,
+    });
+  }
+
+  /**
+   * Checks if multiple feature flags are active for a context, including optional external subjects.
+   */
+  async areActiveForContext({
+    names,
+    user,
+    roles,
+    groups,
+    subjects,
+  }: {
+    names?: string[];
+    user?: string;
+    roles?: string[];
+    groups?: string[];
+    subjects?: string[];
+  }): Promise<Record<string, boolean>> {
     let flags: FeatureFlag[];
     let requestedNames: string[];
 
@@ -577,6 +722,7 @@ export class FeatureFlagModel {
 
     const flagMap = new Map(flags.map((flag) => [flag.name, flag]));
     const result: Record<string, boolean> = {};
+    const subjectMatchedFlagIds = await this.getSubjectMatchedFlagIds(subjects);
 
     for (const name of requestedNames) {
       const flag = flagMap.get(name);
@@ -603,6 +749,8 @@ export class FeatureFlagModel {
         user,
         roles,
         groups,
+        subjects,
+        subjectMatchedFlagIds,
       });
     }
 
@@ -941,6 +1089,59 @@ export class FeatureFlagGroupModel {
       ORDER BY g.created DESC
     `;
     const res = await this.db.query(sql, [featureFlagId]);
+    return res.rows.map(mapGroupRow);
+  }
+
+  /**
+   * Adds an external subject identifier to a feature flag group.
+   */
+  async addSubject(groupId: number, subject: string): Promise<boolean> {
+    try {
+      const sql = `INSERT INTO ${GROUP_SUBJECT_TABLE} (feature_flag_group_id, subject)
+        VALUES ($1, $2)`;
+      await this.db.query(sql, [groupId, subject]);
+      return true;
+    } catch (err: any) {
+      if (err.code === "23505") {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Removes an external subject identifier from a feature flag group.
+   */
+  async removeSubject(groupId: number, subject: string): Promise<boolean> {
+    const sql = `DELETE FROM ${GROUP_SUBJECT_TABLE}
+      WHERE feature_flag_group_id = $1 AND subject = $2`;
+    const res = await this.db.query(sql, [groupId, subject]);
+    return (res as any).rowCount > 0;
+  }
+
+  /**
+   * Gets all external subject identifiers associated with a feature flag group.
+   */
+  async getSubjects(groupId: number): Promise<string[]> {
+    const sql = `SELECT subject FROM ${GROUP_SUBJECT_TABLE}
+      WHERE feature_flag_group_id = $1
+      ORDER BY created DESC`;
+    const res = await this.db.query(sql, [groupId]);
+    return res.rows.map((row: any) => row.subject as string);
+  }
+
+  /**
+   * Gets all groups that are associated with a specific external subject identifier.
+   */
+  async getGroupsForSubject(subject: string): Promise<FeatureFlagGroup[]> {
+    const sql = `
+      SELECT ${GROUP_COLUMNS.map((c) => `g.${c}`).join(", ")}
+      FROM ${GROUP_TABLE} g
+      INNER JOIN ${GROUP_SUBJECT_TABLE} gs ON g.id = gs.feature_flag_group_id
+      WHERE gs.subject = $1
+      ORDER BY g.created DESC
+    `;
+    const res = await this.db.query(sql, [subject]);
     return res.rows.map(mapGroupRow);
   }
 


### PR DESCRIPTION
- feat: add subject mapping schema for direct flag subjects and feature-flag-group subjects with uniqueness and cascade constraints

- feat: extend feature evaluation with isActiveForContext and areActiveForContext to resolve external subject matches while preserving legacy user-based APIs

- feat: add subject-aware caching inputs so context checks are cached correctly by subjects along with user, roles, and groups

- feat: expand CLI with context, subject, and feature-flag-group commands for bulk checks, subject assignment, group membership, and group-level updates

- build: align dev migration command with explicit schema creation and migration table configuration